### PR TITLE
Always hide the overview when a new window is opened.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Auto Activities
-Show activities overview when there are no windows on GNOME.
+Show activities overview when there are no windows, or hide it when there are new windows on GNOME.
 
 [![License][license-badge]][license-link]
 [![Latest Release][release-badge]][release-link]

--- a/autoActivities.js
+++ b/autoActivities.js
@@ -94,7 +94,7 @@ var AutoActivities = GObject.registerClass(
     }
 
     _onWindowAdded(_sender, addedWindow) {
-      if (!ignoredWindowTypes.includes(addedWindow.get_window_type()) && this._settings.get_boolean('close-on-new-window')) {
+      if (!ignoredWindowTypes.includes(addedWindow.get_window_type()) && this._settings.get_boolean('hide-on-new-window')) {
         if (Main.overview.visible)
           Main.overview.hide();
       }

--- a/autoActivities.js
+++ b/autoActivities.js
@@ -30,6 +30,7 @@ var AutoActivities = GObject.registerClass(
       this._remoteModel = remoteModel;
       this._monitorIndex = monitorIndex;
       this._windowRemovedEvents = [];
+      this._windowAddedEvents = [];
       this._settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.auto-activities');
     
       for (let i = 0; i < global.workspace_manager.n_workspaces; i++)
@@ -45,11 +46,15 @@ var AutoActivities = GObject.registerClass(
     _onWorkspaceAdded(_sender, workspaceIndex) {
       let windowRemovedEvent = global.workspace_manager.get_workspace_by_index(workspaceIndex).connect('window-removed', this._onWindowRemoved.bind(this)); 
       this._windowRemovedEvents.push(windowRemovedEvent);
+      let windowAddedEvent = global.workspace_manager.get_workspace_by_index(workspaceIndex).connect('window-added', this._onWindowAdded.bind(this));
+      this._windowAddedEvents.push(windowAddedEvent);
     }
 
     _onWorkspaceRemoved(_sender, workspaceIndex) {
-      if (workspaceIndex < this._windowRemovedEvents.length)
+      if (workspaceIndex < this._windowRemovedEvents.length) {
         this._windowRemovedEvents.splice(workspaceIndex);
+        this._windowAddedEvents.splice(workspaceIndex);
+      }
     }
 
     _onWorkspaceSwitched(_sender, _oldWorkspaceIndex, _newWorkspaceIndex, _direction) {
@@ -72,6 +77,10 @@ var AutoActivities = GObject.registerClass(
       let tempFirstWorkspaceRemovedEvent = this._windowRemovedEvents[firstWorkspaceIndex];
       this._windowRemovedEvents[firstWorkspaceIndex] = this._windowRemovedEvents[secondWorkspaceIndex];
       this._windowRemovedEvents[secondWorkspaceIndex] = tempFirstWorkspaceRemovedEvent;
+
+      let tempFirstWorkspaceAddedEvent = this._windowAddedEvents[firstWorkspaceIndex];
+      this._windowAddedEvents[firstWorkspaceIndex] = this._windowAddedEvents[secondWorkspaceIndex];
+      this._windowAddedEvents[secondWorkspaceIndex] = tempFirstWorkspaceAddedEvent;
     }
 
     _onWindowMinimized(_sender, actor) {
@@ -82,6 +91,13 @@ var AutoActivities = GObject.registerClass(
     _onWindowRemoved(_sender, removedWindow) {
       if (!ignoredWindowTypes.includes(removedWindow.get_window_type()))
         this._checkAndShowOverview();
+    }
+
+    _onWindowAdded(_sender, addedWindow) {
+      if (!ignoredWindowTypes.includes(addedWindow.get_window_type()) && this._settings.get_boolean('close-on-new-window')) {
+        if (Main.overview.visible)
+          Main.overview.hide();
+      }
     }
 
     _checkAndShowOverview() {
@@ -116,6 +132,11 @@ var AutoActivities = GObject.registerClass(
       for (let i = 0; i < this._windowRemovedEvents.length; i++) {
         if (GObject.signal_handler_is_connected(global.workspace_manager.get_workspace_by_index(i), this._windowRemovedEvents[i]))
           global.workspace_manager.get_workspace_by_index(i).disconnect(this._windowRemovedEvents[i]);
+      }
+
+      for (let i = 0; i < this._windowAddedEvents.length; i++) {
+        if (GObject.signal_handler_is_connected(global.workspace_manager.get_workspace_by_index(i), this._windowAddedEvents[i]))
+          global.workspace_manager.get_workspace_by_index(i).disconnect(this._windowAddedEvents[i]);
       }
     }
   });

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
   "name": "Auto Activities",
-  "description": "Show activities overview when there are no windows.",
+  "description": "Show activities overview when there are no windows, or hide it when there are new windows.",
   "uuid": "auto-activities@acedron.github.io",
   "shell-version": [ "40" ],
   "url": "https://github.com/acedron/auto-activities",
   "original-author": "acedrons@yahoo.co.jp",
-  "version": 10,
+  "version": 11,
   "gettext-domain": "auto-activities"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -58,6 +58,10 @@ function buildPrefsWidget() {
   detectMinimized.set_active(settings.get_boolean('detect-minimized'));
   settings.bind('detect-minimized', detectMinimized, 'active', Gio.SettingsBindFlags.DEFAULT);
 
+  let closeOnNewWindow = builder.get_object('CloseOnNewWindowSwitch');
+  closeOnNewWindow.set_active(settings.get_boolean('close-on-new-window'));
+  settings.bind('close-on-new-window', closeOnNewWindow, 'active', Gio.SettingsBindFlags.DEFAULT);
+
   let checkingDelay = builder.get_object('CheckingDelayEntry');
   checkingDelay.set_text(settings.get_string('window-checking-delay'));
   settings.bind('window-checking-delay', checkingDelay, 'text', Gio.SettingsBindFlags.DEFAULT);

--- a/prefs.js
+++ b/prefs.js
@@ -58,9 +58,9 @@ function buildPrefsWidget() {
   detectMinimized.set_active(settings.get_boolean('detect-minimized'));
   settings.bind('detect-minimized', detectMinimized, 'active', Gio.SettingsBindFlags.DEFAULT);
 
-  let closeOnNewWindow = builder.get_object('CloseOnNewWindowSwitch');
-  closeOnNewWindow.set_active(settings.get_boolean('close-on-new-window'));
-  settings.bind('close-on-new-window', closeOnNewWindow, 'active', Gio.SettingsBindFlags.DEFAULT);
+  let hideOnNewWindow = builder.get_object('HideOnNewWindowSwitch');
+  hideOnNewWindow.set_active(settings.get_boolean('hide-on-new-window'));
+  settings.bind('hide-on-new-window', hideOnNewWindow, 'active', Gio.SettingsBindFlags.DEFAULT);
 
   let checkingDelay = builder.get_object('CheckingDelayEntry');
   checkingDelay.set_text(settings.get_string('window-checking-delay'));

--- a/prefs.ui
+++ b/prefs.ui
@@ -111,21 +111,21 @@
     </child>
     <child>
       <!-- n-columns=2 n-rows=1 -->
-      <object class="GtkGrid" id="CloseOnNewWindowGrid">
+      <object class="GtkGrid" id="HideOnNewWindowGrid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">end</property>
         <property name="margin-bottom">8</property>
         <child>
-          <object class="GtkLabel" id="CloseOnNewWindowLabel">
+          <object class="GtkLabel" id="HideOnNewWindowLabel">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="margin-end">16</property>
-            <property name="label" translatable="yes">Close Overview on New Window</property>
+            <property name="label" translatable="yes">Always Hide Overview on New Window</property>
           </object>
         </child>
         <child>
-          <object class="GtkSwitch" id="CloseOnNewWindowSwitch">
+          <object class="GtkSwitch" id="HideOnNewWindowSwitch">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="valign">end</property>

--- a/prefs.ui
+++ b/prefs.ui
@@ -111,6 +111,30 @@
     </child>
     <child>
       <!-- n-columns=2 n-rows=1 -->
+      <object class="GtkGrid" id="CloseOnNewWindowGrid">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">end</property>
+        <property name="margin-bottom">8</property>
+        <child>
+          <object class="GtkLabel" id="CloseOnNewWindowLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-end">16</property>
+            <property name="label" translatable="yes">Close Overview on New Window</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="CloseOnNewWindowSwitch">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="valign">end</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <!-- n-columns=2 n-rows=1 -->
       <object class="GtkGrid" id="CheckingDelayGrid">
         <property name="visible">True</property>
         <property name="can-focus">True</property>

--- a/schemas/org.gnome.shell.extensions.auto-activities.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.auto-activities.gschema.xml
@@ -13,7 +13,7 @@
     <key name="detect-minimized" type="b">
       <default>false</default>
     </key>
-    <key name="close-on-new-window" type="b">
+    <key name="hide-on-new-window" type="b">
       <default>false</default>
     </key>
     <key name="window-checking-delay" type="s">

--- a/schemas/org.gnome.shell.extensions.auto-activities.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.auto-activities.gschema.xml
@@ -13,6 +13,9 @@
     <key name="detect-minimized" type="b">
       <default>false</default>
     </key>
+    <key name="close-on-new-window" type="b">
+      <default>false</default>
+    </key>
     <key name="window-checking-delay" type="s">
       <default>"100"</default>
     </key>


### PR DESCRIPTION
# Changelog
* Add an option to always hide the overview when a new window is opened.

Closes #13.